### PR TITLE
Http examples

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="app.rive.runtime.example">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -23,6 +26,7 @@
         <activity android:name=".LayoutActivity" />
         <activity android:name=".RiveFragmentActivity" />
         <activity android:name=".LowLevelActivity" />
+        <activity android:name=".HttpActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/app/rive/runtime/example/HttpActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/HttpActivity.kt
@@ -1,0 +1,73 @@
+package app.rive.runtime.example
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.rive.runtime.kotlin.RiveAnimationView
+import app.rive.runtime.kotlin.core.Fit
+import app.rive.runtime.kotlin.core.Rive
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.URL
+
+class HttpActivity : AppCompatActivity() {
+    // Url of the Rive file
+    private val riveUrl = "https://cdn.rive.app/animations/juice_v7.riv"
+
+    // Rive animation view, from the layout xml
+    private val animationView by lazy(LazyThreadSafetyMode.NONE) {
+        findViewById<RiveAnimationView>(R.id.http_view)
+    }
+
+    // ViewModel for fetching http data asynchronously
+    private val httpViewModel by viewModels<HttpViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Rive.init()
+        setContentView(R.layout.activity_http)
+
+        // Load the Rive data asynchronously
+        httpViewModel.byteLiveData.observe(
+            this,
+            Observer { bytes ->
+                // Pass the Rive file bytes to the animation view
+                animationView.setRiveBytes(
+                    bytes,
+                    // Fit the animation to the cover the entire view
+                    fit = Fit.COVER
+                )
+            }
+        )
+        httpViewModel.fetchUrl(riveUrl)
+    }
+
+    // Clean up the animation view
+    override fun onDestroy() {
+        super.onDestroy()
+        animationView.destroy()
+    }
+}
+
+// ViewModel for asynchronously fetching Rive file data
+// Using a 3rd party http library is recommended
+class HttpViewModel : ViewModel() {
+    val byteLiveData = MutableLiveData<ByteArray>()
+
+    fun fetchUrl(url: String) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                fetchAsync(url)
+            }
+        }
+    }
+
+    private fun fetchAsync(url: String) {
+        byteLiveData.postValue(URL(url).openStream().use { it.readBytes() })
+    }
+}

--- a/app/src/main/java/app/rive/runtime/example/MainActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/MainActivity.kt
@@ -54,5 +54,11 @@ class MainActivity : AppCompatActivity() {
                     Intent(this, LowLevelActivity::class.java)
             )
         }
+
+        findViewById<Button>(R.id.go_http).setOnClickListener {
+            startActivity(
+                Intent(this, HttpActivity::class.java)
+            )
+        }
     }
 }

--- a/app/src/main/java/app/rive/runtime/example/SimpleActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/SimpleActivity.kt
@@ -7,7 +7,7 @@ import app.rive.runtime.kotlin.core.Rive
 
 class SimpleActivity : AppCompatActivity() {
 
-    val animationView by lazy(LazyThreadSafetyMode.NONE) {
+    private val animationView by lazy(LazyThreadSafetyMode.NONE) {
         findViewById<RiveAnimationView>(R.id.simple_view)
     }
 

--- a/app/src/main/res/layout/activity_http.xml
+++ b/app/src/main/res/layout/activity_http.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".HttpActivity">
+
+    <app.rive.runtime.kotlin.RiveAnimationView
+        android:id="@+id/http_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/example_selection.xml
+++ b/app/src/main/res/layout/example_selection.xml
@@ -58,6 +58,12 @@
                 android:layout_height="wrap_content"
                 android:text="Low Level Renderer" />
 
+            <Button
+                android:id="@+id/go_http"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="HTTP" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveAnimationView.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveAnimationView.kt
@@ -303,7 +303,40 @@ class RiveAnimationView(context: Context, attrs: AttributeSet? = null) : View(co
         loop: Loop = drawable.loop,
     ) {
         resourceId = resId
-        val file = File(resources.openRawResource(resId).readBytes())
+        val bytes = resources.openRawResource(resId).readBytes()
+        setRiveBytes(
+            bytes,
+            fit = fit,
+            alignment = alignment,
+            loop = loop,
+            artboardName = artboardName,
+            animationName = animationName,
+            autoplay = autoplay
+        )
+    }
+
+    /**
+     * Create a view file from a byte array and load it into the view
+     *
+     * - Optionally provide an [artboardName] to use, or the first artboard in the file.
+     * - Optionally provide an [animationName] to load by default, playing without any suggested animations names will simply play the first animaiton
+     * - Enable [autoplay] to start the animation without further prompts.
+     * - Configure [alignment] to specify how the animation should be aligned to its container.
+     * - Configure [fit] to specify how and if the animation should be resized to fit its container.
+     * - Configure [loop] to configure if animations should loop, play once, or pingpong back and forth. Defaults to the setup in the rive file.
+     *
+     * @throws [RiveException] if [artboardName] or [animationName] are set and do not exist in the file.
+     */
+    fun setRiveBytes(
+        bytes: ByteArray,
+        artboardName: String? = drawable.artboardName,
+        animationName: String? = drawable.animationName,
+        autoplay: Boolean = drawable.autoplay,
+        fit: Fit = drawable.fit,
+        alignment: Alignment = drawable.alignment,
+        loop: Loop = drawable.loop,
+    ) {
+        val file = File(bytes)
         setRiveFile(
             file,
             fit = fit,


### PR DESCRIPTION
fixes #83 
fixes #84 

I used the framework's ```URL``` library, which adds a bunch of async boilerplate stuff, but I didn't want to add a 3rd party dependency.