### PR TITLE
Simplify git actions attempt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
   
   publish:
     name: Release build and publish
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,27 +5,27 @@ on:
     types: [released]
 
 jobs:
-  build:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.RIVE_REPO_PAT }}
-          submodules: recursive
-      - name: Init submodule
-        run: git submodule update --init
-      - name: Build Android
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 30
-          target: google_apis
-          script: ./gradlew kotlin:assembleRelease
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: rive
-          path: kotlin/build/outputs/aar/kotlin-release.aar
+  # build:
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         token: ${{ secrets.RIVE_REPO_PAT }}
+  #         submodules: recursive
+  #     - name: Init submodule
+  #       run: git submodule update --init
+  #     - name: Build Android
+  #       uses: reactivecircus/android-emulator-runner@v2
+  #       with:
+  #         api-level: 30
+  #         target: google_apis
+  #         script: ./gradlew kotlin:assembleRelease
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: rive
+  #         path: kotlin/build/outputs/aar/kotlin-release.aar
   
   publish:
     name: Release build and publish
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
       # Base64 decodes and pipes the GPG key content into the secret file
       - name: Prepare environment
         env:
@@ -46,19 +47,14 @@ jobs:
         run: |
           git fetch --unshallow
           sudo bash -c "echo '$GPG_KEY_CONTENTS' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
+
       # Builds the release artifacts of the library
-      - name: Download framework artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: rive
-          path: kotlin/build/outputs/aar/kotlin-release.aar
+      - name: Build Android
+        run: ./gradlew kotlin:assembleRelease
+
       # Runs upload, and then closes & releases the repository
       - name: Publish to MavenCentral
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 30
-          target: google_apis
-          script: ./gradlew publishAllPublicationsToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishAllPublicationsToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -54,14 +54,14 @@ dependencies {
 
 }
 
+// Commenting this out, this only really helps when you're doing local dev, but it means our git actions need abd!
+// static def getDeviceAbi() {
+//     return "adb shell getprop ro.product.cpu.abi".execute().text.trim()
+// }
 
-static def getDeviceAbi() {
-    return "adb shell getprop ro.product.cpu.abi".execute().text.trim()
-}
-
-task buildJNI(type: Exec) {
-    workingDir '../cpp'
-    commandLine './build.rive.for.sh', '-a', getDeviceAbi()
-}
+// task buildJNI(type: Exec) {
+//     workingDir '../cpp'
+//     commandLine './build.rive.for.sh', '-a', getDeviceAbi()
+// }
 
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"


### PR DESCRIPTION
alright this looks to simplify things down a bit. we no longer need adb at all right now. (we'll need it once we want to run tests, as they're instrumented) but we don't for building the app! woop