### PR TITLE
added script to compare rive cpp submodule to rive-cpp

### DIFF
--- a/.github/scripts/rive_cpp_check.sh
+++ b/.github/scripts/rive_cpp_check.sh
@@ -1,0 +1,20 @@
+set -e
+
+# GET hash of CPP MASTER.
+RIVE_CPP_MASTER_HASH=$(git ls-remote https://github.com/rive-app/rive-cpp.git refs/heads/master | awk '{print $1}')
+echo rive-cpp master is at $RIVE_CPP_MASTER_HASH
+
+
+# GET hash of Submodule.
+RIVE_ANDROID_CPP_SUBMODULE_HASH=$(git submodule | grep rive-cpp |awk '{print $1}' | sed -En 's/-*(.*)/\1/p')
+
+echo rive-android cpp submodule is at $RIVE_ANDROID_CPP_SUBMODULE_HASH
+
+if [ "$RIVE_CPP_MASTER_HASH" == "$RIVE_ANDROID_CPP_SUBMODULE_HASH" ]
+then 
+    echo "They match. all is good"
+else 
+    # Just full on assuming this is behind for the time being. 
+    # Could put in some 'useful' links into this message. Once we have something useful to do (other than update & rebuild)
+    curl -X POST -H 'Content-type: application/json' --data '{"text":"`rive-android` is behind rive-cpp!"}' $SLACK_WEBHOOK
+fi 

--- a/.github/workflows/submodule_check.yml
+++ b/.github/workflows/submodule_check.yml
@@ -1,0 +1,24 @@
+name: Check Rive-Android sub modules
+
+on:
+  # lets check it when we push to master (we've just done something in android, its a good time to see about this)
+  push:
+    branches:
+      - master
+  
+  schedule:
+    # 8am UTC every day
+    - cron:  '0 8 * * *'
+
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Run cpp version check 
+        env:
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: sh ./.github/scripts/rive_cpp_check.sh


### PR DESCRIPTION
fixes #138 

checks rive-android on a schedule (presumably, not actually tested the schedule part works) 
checks rive-android when merging to master (cos thats probably a good time to alert that you might as well rev cpp)

posts a thing to slack if rive-cpp head != submodule/cpp head. 