### PR TITLE
We need to sort out or proguard rules if we want to enable minify

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -19,7 +19,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
not 100% sure this will fix it. but our latest android version is not exposing any class names, which makes it less than useful.

this is the most likely change to that from 2.8 to 2.9 

our test app works either way sadly, i guess it can work out which parts it needs whenever it wants. 