### PR TITLE
update to use relinker

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.5.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.getkeepsafe.relinker:relinker:1.4.4'
     implementation 'androidx.startup:startup-runtime:1.1.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core-ktx:1.3.0'

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/core/Rive.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/core/Rive.kt
@@ -1,14 +1,8 @@
 package app.rive.runtime.kotlin.core
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Build
-import android.util.Log
-import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
-import java.io.InputStream
-import java.util.zip.ZipFile
+import com.getkeepsafe.relinker.ReLinker
+
 
 object Rive {
     private external fun cppInitialize()
@@ -20,43 +14,6 @@ object Rive {
     )
 
     private const val JNIRiveBridge = "jnirivebridge"
-    private const val JNIRiveBridgeSO = "lib${JNIRiveBridge}.so"
-
-    private var libLoaded = false
-    private var apkFile: ZipFile? = null
-
-    private fun getApkFile(context: Context): ZipFile {
-        if (apkFile != null) {
-            return apkFile!!
-        }
-
-        val apkLocation = context.applicationInfo.sourceDir
-        val file = File(apkLocation)
-        if (!file.exists()) {
-            Log.e("Rive", "No apk file for this Activity?!")
-            throw IOException("Missing APK file in this context $apkLocation")
-        }
-
-        // Return and assign.
-        return ZipFile(apkLocation).also { apkFile = it }
-    }
-
-
-    private val abiCount: Int
-        get() = when {
-            // Do we need this? We're already restricting to be SDK >= 21
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-            -> Build.SUPPORTED_ABIS.size
-            else -> 1
-        }
-
-    private fun getAbiName(index: Int): String {
-        // Do we need this? We're already restricting to be SDK >= 21
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            Build.SUPPORTED_ABIS[index]
-        } else Build.CPU_ABI
-    }
-
 
     /**
      * Initialises Rive.
@@ -66,137 +23,12 @@ object Rive {
      * it can interact with Java objects.
      */
     fun init(context: Context) {
-        try {
-            System.loadLibrary(JNIRiveBridge)
-        } catch (err: UnsatisfiedLinkError) {
-            extractLib(context)
-        }
+        // NOTE: loadLibrary also allows us to specify a version, something we might want to take
+        //       advantage of
+        ReLinker.loadLibrary(context, JNIRiveBridge);
         cppInitialize()
     }
 
-    @SuppressLint("UnsafeDynamicallyLoadedCode")
-    private fun extractLib(context: Context) {
-        var i = 0
-        val maxTries = abiCount
-        while (!libLoaded && i < maxTries) {
-            val destDir = File(context.filesDir, "lib")
-            destDir.mkdirs()
-
-            val destLocalFile = File(destDir, "lib${JNIRiveBridge}loc.so")
-            if (destLocalFile.exists()) {
-                try {
-                    System.load(destLocalFile.absolutePath)
-                    libLoaded = true
-                    return
-                } catch (_: Error) {
-                }
-                destLocalFile.delete()
-            }
-
-            try {
-                destDir.listFiles()?.forEach { it.delete() }
-            } catch (_: Exception) {
-            }
-
-            val abiName = getAbiName(i)
-            val abiFolder = getFolderFrom(abiName)
-            try {
-                if (loadFromZip(context, destLocalFile, abiFolder)) {
-                    if (libLoaded) return
-                }
-            } catch (_: Exception) {
-            }
-
-            i++
-        }
-
-        // Don't give up.
-        try {
-            System.loadLibrary(JNIRiveBridge)
-            libLoaded = true
-        } catch (e: Error) {
-            e.printStackTrace()
-        }
-
-        if (!libLoaded) {
-            Log.e("Rive", "Failed to initialize JNI Rive Bridge")
-        }
-    }
-
-    private fun getFolderFrom(abi: String): String {
-        var folder: String
-        folder = when {
-            abi.equals("x86_64", true) -> {
-                "x86_64"
-            }
-            abi.equals("arm64-v8a", true) -> {
-                "arm64-v8a"
-            }
-            abi.equals("armeabi-v7a", true) -> {
-                "armeabi-v7a"
-            }
-            abi.equals("armeabi", true) -> {
-                "armeabi"
-            }
-            abi.equals("x86", true) -> {
-                "x86"
-            }
-            abi.equals("mips", true) -> {
-                "mips"
-            }
-            else -> {
-                "armeabi"
-            }
-        }
-
-        val sysArch = System.getProperty("os.arch")
-        if (sysArch != null) if (sysArch.contains("686") || sysArch.contains("x86")) {
-            folder = "x86"
-        }
-        return folder
-    }
-
-
-    @Throws(IOException::class)
-    @SuppressLint("UnsafeDynamicallyLoadedCode")
-    private fun loadFromZip(context: Context, destLocalFile: File, abiFolder: String): Boolean {
-        val apkFile = getApkFile(context)
-        val libEntryLocation = "lib/$abiFolder/$JNIRiveBridgeSO"
-        val libEntry = apkFile.getEntry(libEntryLocation)
-        if (libEntry == null) {
-            apkFile.close()
-            throw IOException("No $libEntryLocation in apkFile")
-        }
-        val stream = apkFile.getInputStream(libEntry)
-
-        writeLibStream(stream, destLocalFile)
-        return try {
-            System.load(destLocalFile.absolutePath)
-            libLoaded = true
-            true
-        } catch (_: Error) {
-            false
-        } finally {
-            // Clean up resources before returning.
-            stream.close()
-            apkFile.close()
-        }
-    }
-
-    @SuppressLint("SetWorldReadable")
-    private fun writeLibStream(inputStream: InputStream, destLocalFile: File) {
-        val outputStream = FileOutputStream(destLocalFile)
-        val bytesArray = ByteArray(4096)
-        var read: Int
-        while (inputStream.read(bytesArray).also { read = it } != -1) {
-            Thread.yield()
-            outputStream.write(bytesArray, 0, read)
-        }
-        outputStream.close()
-        destLocalFile.setReadable(true, false)
-        destLocalFile.setExecutable(true, false)
-        destLocalFile.setWritable(true)
-    }
 
     fun calculateRequiredBounds(
         fit: Fit,


### PR DESCRIPTION
we can also go for versioned .so files

i think that means that we will want to supply those though as part of building our app (which we can do)

```
Versioning
In the event that your library's code is changed, it is a good idea to specify a specific version. Doing so will allow ReLinker to update the workaround library file successfully. In the case that the system handles the library loading appropriately, the version specified is not used as all library files are extracted and replaced on update or install.

To specify a version for your library simply provide it as an additional parameter for loadLibrary like:

ReLinker.loadLibrary(context, "mylibrary", "1.0");
This will cause ReLinker to look for, and load libmylibrary.so.1.0. Subsequent version updates will automatically clean up all other library versions.
```

we could track a version number in Rive.kt  and update it when we build the .so's with something like this  (im sure someone with more bash foo can make that nicer)

```
# https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

# increment the SOVersion by 1. 
RIVE_KT=$SCRIPT_DIR/../kotlin/src/main/java/app/rive/runtime/kotlin/core/Rive.kt
CURRENT_VERSION=`cat $RIVE_KT |grep "SOVersion = " | grep -Eo "\d+"`
NEW_VERSION=$((CURRENT_VERSION+1))

sed -i '' 's/SOVersion = "'"$CURRENT_VERSION"'"/SOVersion = "'"$NEW_VERSION"'"/' $RIVE_KT
```