### PR TITLE
Swappy tests

### DIFF
--- a/cpp/src/bindings/bindings_file.cpp
+++ b/cpp/src/bindings/bindings_file.cpp
@@ -17,7 +17,7 @@ extern "C"
         jint length)
     {
         rive_android::setSDKVersion();
-        auto file = ::import(
+        auto file = import(
             (uint8_t *)env->GetByteArrayElements(bytes, NULL),
             length);
         return (jlong)file;

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveAnimationConfigurationsTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveAnimationConfigurationsTest.kt
@@ -9,10 +9,11 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveAnimationConfigurationsTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun loop() {
-        val appContext = initTests()
         val file =
             File(appContext.resources.openRawResource(R.raw.animationconfigurations).readBytes())
         val animation = file.firstArtboard.animation("loop")
@@ -21,7 +22,6 @@ class RiveAnimationConfigurationsTest {
 
     @Test
     fun pingpong() {
-        val appContext = initTests()
         val file =
             File(appContext.resources.openRawResource(R.raw.animationconfigurations).readBytes())
         val animation = file.firstArtboard.animation("pingpong")
@@ -30,7 +30,6 @@ class RiveAnimationConfigurationsTest {
 
     @Test
     fun oneshot() {
-        val appContext = initTests()
         val rawResource = appContext.resources.openRawResource(R.raw.animationconfigurations)
         val file = File(rawResource.readBytes())
         val animation = file.firstArtboard.animation("oneshot")
@@ -39,7 +38,6 @@ class RiveAnimationConfigurationsTest {
 
     @Test
     fun checkdurations1sec60fps() {
-        val appContext = initTests()
         val file =
             File(appContext.resources.openRawResource(R.raw.animationconfigurations).readBytes())
         val animation = file.firstArtboard.animation("1sec60fps")
@@ -52,7 +50,6 @@ class RiveAnimationConfigurationsTest {
 
     @Test
     fun checkdurations1sec120fps() {
-        val appContext = initTests()
         val file =
             File(appContext.resources.openRawResource(R.raw.animationconfigurations).readBytes())
         val animation = file.firstArtboard.animation("1sec120fps")
@@ -65,7 +62,6 @@ class RiveAnimationConfigurationsTest {
 
     @Test
     fun checkdurations1sec60fps_f30f50() {
-        val appContext = initTests()
         val file =
             File(appContext.resources.openRawResource(R.raw.animationconfigurations).readBytes())
         val animation = file.firstArtboard.animation("1sec60fps_f30f50")
@@ -78,7 +74,6 @@ class RiveAnimationConfigurationsTest {
 
     @Test
     fun checkdurations1sec120fps_f30f50() {
-        val appContext = initTests()
         val file =
             File(appContext.resources.openRawResource(R.raw.animationconfigurations).readBytes())
         val animation = file.firstArtboard.animation("1sec120fps_f50f80")

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveAnimationLoadTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveAnimationLoadTest.kt
@@ -10,10 +10,11 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveAnimationLoadTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun loadAnimationFirstAnimation() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         var artboard = file.artboard("artboard1")
 
@@ -25,7 +26,6 @@ class RiveAnimationLoadTest {
 
     @Test
     fun loadAnimationSecondAnimation() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         var artboard = file.artboard("artboard2")
         var artboard2animation1 = artboard.animation(0)
@@ -40,7 +40,6 @@ class RiveAnimationLoadTest {
 
     @Test
     fun artboardHasNoAnimations() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         assertEquals(0, artboard.animationCount)
@@ -49,7 +48,6 @@ class RiveAnimationLoadTest {
 
     @Test(expected = AnimationException::class)
     fun loadFirstAnimationNoExists() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         artboard.firstAnimation
@@ -57,7 +55,6 @@ class RiveAnimationLoadTest {
 
     @Test(expected = AnimationException::class)
     fun loadAnimationByIndexDoesntExist() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         artboard.animation(1)
@@ -65,7 +62,6 @@ class RiveAnimationLoadTest {
 
     @Test(expected = AnimationException::class)
     fun loadAnimationByNameDoesntExist() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         artboard.animation("foo")

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveArtboardLoadTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveArtboardLoadTest.kt
@@ -10,9 +10,10 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveArtboardLoadTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
     @Test
     fun loadArtboard() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         // Access an artboard can bail when we don't have one.
         file.firstArtboard
@@ -31,14 +32,12 @@ class RiveArtboardLoadTest {
 
     @Test(expected = RiveException::class)
     fun loadArtboardNoArtboard() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noartboard).readBytes())
         file.firstArtboard
     }
 
     @Test
     fun loadArtboardNoArtboardCheck() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noartboard).readBytes())
         assertEquals(0, file.artboardCount);
         assertEquals(listOf<String>(), file.artboardNames)
@@ -46,7 +45,6 @@ class RiveArtboardLoadTest {
 
     @Test
     fun loadArtboardOne() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         var artboard1 = file.artboard(name = "artboard1")
         assertEquals(1, artboard1.animationCount);
@@ -58,7 +56,6 @@ class RiveArtboardLoadTest {
 
     @Test
     fun loadArtboardTwo() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         var artboard2 = file.artboard(name = "artboard2")
         assertEquals(2, artboard2.animationCount);
@@ -68,14 +65,12 @@ class RiveArtboardLoadTest {
 
     @Test(expected = RiveException::class)
     fun loadArtboardThree() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         file.artboard(name = "artboard3")
     }
 
     @Test(expected = RiveException::class)
     fun loadArtboardThreeAlt() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         file.artboard(2)
     }
@@ -83,7 +78,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesRect() {
         // TODO: access properties once exposed & attempt drawing?
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "rect")
         // can we do a draw check?
@@ -92,7 +86,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesEllipse() {
         // TODO: access properties once exposed & attempt drawing?
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "ellipse")
     }
@@ -100,7 +93,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesTriangle() {
         // TODO: access properties once exposed & attempt drawing?
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "triangle")
     }
@@ -108,7 +100,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesPolygon() {
         // TODO: access properties once exposed & attempt drawing?
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "polygon")
     }
@@ -116,7 +107,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesStar() {
         // TODO: access properties once exposed & attempt drawing?
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "star")
     }
@@ -124,7 +114,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesPen() {
         // TODO: access properties once exposed & attempt drawing?¬
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "pen")
     }
@@ -132,7 +121,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesGroups() {
         // TODO: access properties once exposed & attempt drawing?¬
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "groups")
     }
@@ -140,7 +128,6 @@ class RiveArtboardLoadTest {
     @Test
     fun loadShapesBone() {
         // TODO: access properties once exposed & attempt drawing?¬
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.shapes).readBytes())
         file.artboard(name = "bone")
     }

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveEventTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveEventTest.kt
@@ -6,7 +6,6 @@ import app.rive.runtime.kotlin.RiveAnimationView
 import app.rive.runtime.kotlin.RiveDrawable
 import app.rive.runtime.kotlin.test.R
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -40,11 +39,12 @@ class Observer : RiveDrawable.Listener {
 
 @RunWith(AndroidJUnit4::class)
 class RiveEventTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun testRegisterOrder() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -59,7 +59,6 @@ class RiveEventTest {
     @Test
     fun testPlayEvent() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -75,7 +74,6 @@ class RiveEventTest {
     @Test
     fun testPlayEventAlreadyPlaying() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -94,7 +92,6 @@ class RiveEventTest {
     @Test
     fun testPauseEvent() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -112,7 +109,6 @@ class RiveEventTest {
     @Test
     fun testPauseEventNotPlaying() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -129,7 +125,6 @@ class RiveEventTest {
     @Test
     fun testStopEvent() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -147,7 +142,6 @@ class RiveEventTest {
     @Test
     fun testStopEventNotPlaying() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -163,7 +157,6 @@ class RiveEventTest {
     @Test
     fun testLoopOneshot() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -187,7 +180,6 @@ class RiveEventTest {
     @Test
     fun testLoopLoop() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -211,7 +203,6 @@ class RiveEventTest {
     @Test
     fun testLoopPingPong() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             val observer = Observer()
             view.autoplay = false
@@ -235,7 +226,6 @@ class RiveEventTest {
     @Test
     fun testStateMachineLayerStates() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)
@@ -253,7 +243,6 @@ class RiveEventTest {
     @Test
     fun testStateMachineLayerStatesAnimations() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)
@@ -315,7 +304,6 @@ class RiveEventTest {
     @Test
     fun testStateMachineLayerStatesAnimationsDoubleChange() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)
@@ -336,7 +324,6 @@ class RiveEventTest {
     @Test
     fun viewBlendState1DBroken() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)
@@ -352,7 +339,6 @@ class RiveEventTest {
     @Test
     fun viewBlendStateDirectBroken() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)
@@ -368,7 +354,6 @@ class RiveEventTest {
     @Test
     fun viewBlendState1D() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)
@@ -384,7 +369,6 @@ class RiveEventTest {
     @Test
     fun viewBlendStateDirect() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val observer = Observer()
 
             val view = RiveAnimationView(appContext)

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveFileLoadTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveFileLoadTest.kt
@@ -1,7 +1,8 @@
 package app.rive.runtime.kotlin.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import app.rive.runtime.kotlin.core.errors.*
+import app.rive.runtime.kotlin.core.errors.MalformedFileException
+import app.rive.runtime.kotlin.core.errors.UnsupportedRuntimeVersionException
 import app.rive.runtime.kotlin.test.R
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -10,31 +11,29 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveFileLoadTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test(expected = UnsupportedRuntimeVersionException::class)
     fun loadFormat6() {
-        val appContext = initTests()
         File(appContext.resources.openRawResource(R.raw.sample6).readBytes())
         assert(false);
     }
 
     @Test(expected = MalformedFileException::class)
     fun loadJunk() {
-        val appContext = initTests()
         File(appContext.resources.openRawResource(R.raw.junk).readBytes())
         assert(false);
     }
 
     @Test
     fun loadFormatFlux() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.flux_capacitor).readBytes())
         assertEquals(1, file.firstArtboard.animationCount);
     }
 
     @Test
     fun loadFormatBuggy() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.off_road_car_blog).readBytes())
         assertEquals(5, file.firstArtboard.animationCount);
     }

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineConfigurationsTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineConfigurationsTest.kt
@@ -9,10 +9,11 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveStateMachineConfigurationsTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun nothing() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -24,7 +25,6 @@ class RiveStateMachineConfigurationsTest {
 
     @Test
     fun one_layer() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -37,7 +37,6 @@ class RiveStateMachineConfigurationsTest {
 
     @Test
     fun two_layers() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -49,7 +48,6 @@ class RiveStateMachineConfigurationsTest {
 
     @Test
     fun number_input() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -67,7 +65,6 @@ class RiveStateMachineConfigurationsTest {
 
     @Test
     fun boolean_input() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -85,7 +82,6 @@ class RiveStateMachineConfigurationsTest {
 
     @Test
     fun trigger_input() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -103,7 +99,6 @@ class RiveStateMachineConfigurationsTest {
 
     @Test
     fun mixed() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineInstanceTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineInstanceTest.kt
@@ -9,10 +9,11 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveStateMachineInstanceTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun nothing() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -24,7 +25,6 @@ class RiveStateMachineInstanceTest {
 
     @Test
     fun number_input() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -44,7 +44,6 @@ class RiveStateMachineInstanceTest {
 
     @Test
     fun boolean_input() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -67,7 +66,6 @@ class RiveStateMachineInstanceTest {
 
     @Test
     fun trigger_input() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()
@@ -88,7 +86,6 @@ class RiveStateMachineInstanceTest {
 
     @Test
     fun mixed() {
-        val appContext = initTests()
         var file =
             File(
                 appContext.resources.openRawResource(R.raw.state_machine_configurations).readBytes()

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineLoadTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineLoadTest.kt
@@ -1,7 +1,7 @@
 package app.rive.runtime.kotlin.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import app.rive.runtime.kotlin.core.errors.*
+import app.rive.runtime.kotlin.core.errors.RiveException
 import app.rive.runtime.kotlin.test.R
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -10,10 +10,11 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveStateMachineLoadTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun loadStateMachineFirstStateMachine() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         var artboard = file.artboard("artboard1")
 
@@ -25,7 +26,6 @@ class RiveStateMachineLoadTest {
 
     @Test
     fun loadStateMachineSecondStateMachine() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.multipleartboards).readBytes())
         var artboard = file.artboard("artboard2")
         var artboard2stateMachine1 = artboard.stateMachine(0)
@@ -35,13 +35,16 @@ class RiveStateMachineLoadTest {
         var artboard2stateMachine2 = artboard.stateMachine(1)
         var artboard2stateMachine2Alt = artboard.stateMachine("artboard2stateMachine2")
         assertEquals(artboard2stateMachine2Alt.cppPointer, artboard2stateMachine2.cppPointer)
-        assertEquals(listOf("artboard2stateMachine1", "artboard2stateMachine2"), artboard.stateMachineNames)
+        assertEquals(
+            listOf("artboard2stateMachine1", "artboard2stateMachine2"),
+            artboard.stateMachineNames
+        )
     }
 
     @Test
     fun artboardHasNoStateMachines() {
-        val appContext = initTests()
-        var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
+        val bytes = appContext.resources.openRawResource(R.raw.noanimation).readBytes()
+        val file = File(bytes)
         var artboard = file.firstArtboard
         assertEquals(0, artboard.stateMachineCount)
         assertEquals(listOf<String>(), artboard.stateMachineNames)
@@ -49,7 +52,6 @@ class RiveStateMachineLoadTest {
 
     @Test(expected = RiveException::class)
     fun loadFirstStateMachineNoExists() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         artboard.firstStateMachine
@@ -57,7 +59,6 @@ class RiveStateMachineLoadTest {
 
     @Test(expected = RiveException::class)
     fun loadStateMachineByIndexDoesntExist() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         artboard.stateMachine(1)
@@ -65,7 +66,6 @@ class RiveStateMachineLoadTest {
 
     @Test(expected = RiveException::class)
     fun loadStateMachineByNameDoesntExist() {
-        val appContext = initTests()
         var file = File(appContext.resources.openRawResource(R.raw.noanimation).readBytes())
         var artboard = file.firstArtboard
         artboard.stateMachine("foo")

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewStateMachineTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewStateMachineTest.kt
@@ -70,7 +70,6 @@ class RiveViewStateMachineTest {
         UiThreadStatement.runOnUiThread {
             // state machine four's has transitions that happen instantly, so we do not stick on
             // a state that's playing an animation
-
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_state_machines, stateMachineName = "four")
             assertEquals(false, view.isPlaying)
@@ -82,7 +81,6 @@ class RiveViewStateMachineTest {
     @Test
     fun viewStateMachinesPause() {
         UiThreadStatement.runOnUiThread {
-
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.what_a_state, stateMachineName = "State Machine 2")
             assertEquals(true, view.isPlaying)

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewStateMachineTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewStateMachineTest.kt
@@ -12,18 +12,19 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RiveViewStateMachineTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun viewDefaultsLoadResouce() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_state_machines, autoplay = false)
             view.play(listOf("one", "two"), areStateMachines = true)
 
             assertEquals(true, view.isPlaying)
-            assertEquals(listOf("New Artboard",), view.file?.artboardNames)
+            assertEquals(listOf("New Artboard"), view.file?.artboardNames)
             assertEquals(
                 listOf("one", "two"),
                 view.stateMachines.map { it.stateMachine.name }.toList()
@@ -34,7 +35,6 @@ class RiveViewStateMachineTest {
     @Test
     fun viewDefaultsNoAutoplay() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_state_machines, autoplay = false)
@@ -50,7 +50,6 @@ class RiveViewStateMachineTest {
     @Test
     fun viewPause() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_state_machines, stateMachineName = "one")
@@ -71,7 +70,6 @@ class RiveViewStateMachineTest {
         UiThreadStatement.runOnUiThread {
             // state machine four's has transitions that happen instantly, so we do not stick on
             // a state that's playing an animation
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_state_machines, stateMachineName = "four")
@@ -84,12 +82,11 @@ class RiveViewStateMachineTest {
     @Test
     fun viewStateMachinesPause() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.what_a_state, stateMachineName = "State Machine 2")
             assertEquals(true, view.isPlaying)
-            view.drawable.advance(2000f)
+            view.drawable.advance(2f)
             assertEquals(false, view.isPlaying)
         }
     }
@@ -98,13 +95,12 @@ class RiveViewStateMachineTest {
     @Ignore("We're not stopping state machines when all layers are stopped atm.")
     fun viewStateMachinesInstancesRemoveOnStop() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.what_a_state, stateMachineName = "State Machine 2")
 
             assertEquals(1, view.drawable.stateMachines.size)
-            view.drawable.advance(2000f)
+            view.drawable.advance(2f)
             assertEquals(false, view.isPlaying)
             assertEquals(0, view.drawable.stateMachines.size)
         }

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewTest.kt
@@ -3,22 +3,22 @@ package app.rive.runtime.kotlin.core
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import app.rive.runtime.kotlin.RiveAnimationView
-import app.rive.runtime.kotlin.core.errors.*
+import app.rive.runtime.kotlin.core.errors.RiveException
 import app.rive.runtime.kotlin.test.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 
 @RunWith(AndroidJUnit4::class)
 class RiveViewTest {
+    private val testUtils = TestUtils()
+    private val appContext = testUtils.context
 
     @Test
     fun viewNoDefaults() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
 
             assertEquals(false, view.isPlaying)
@@ -28,7 +28,6 @@ class RiveViewTest {
     @Test
     fun viewDefaultsLoadResouce() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multipleartboards, autoplay = false)
@@ -46,7 +45,6 @@ class RiveViewTest {
     @Test
     fun viewDefaultsChangeArtboard() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multipleartboards)
             assertEquals(true, view.isPlaying)
@@ -62,7 +60,6 @@ class RiveViewTest {
     @Test
     fun viewDefaultsNoAutoplay() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.autoplay = false
@@ -84,7 +81,6 @@ class RiveViewTest {
     @Test
     fun viewPause() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multipleartboards)
@@ -102,7 +98,6 @@ class RiveViewTest {
     @Test
     fun viewPauseOneByOne() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             view.play(listOf("one", "two", "three", "four"))
@@ -144,7 +139,6 @@ class RiveViewTest {
     @Test
     fun viewPauseMultiple() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             view.play(listOf("one", "two", "three", "four"))
@@ -173,7 +167,6 @@ class RiveViewTest {
     @Test
     fun viewPlay() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multipleartboards, autoplay = false)
@@ -190,7 +183,6 @@ class RiveViewTest {
     @Test
     fun viewPlayOneByOne() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             assertEquals(false, view.isPlaying)
@@ -210,7 +202,6 @@ class RiveViewTest {
     @Test(expected = RiveException::class)
     fun viewPlayJunk() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             assertEquals(false, view.isPlaying)
@@ -225,7 +216,6 @@ class RiveViewTest {
     @Test
     fun viewPlayMultiple() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             assertEquals(false, view.isPlaying)
@@ -245,7 +235,6 @@ class RiveViewTest {
     @Test
     fun viewPlayLoopMode() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
 
@@ -274,7 +263,6 @@ class RiveViewTest {
     @Test
     fun viewPlayDirection() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
 
@@ -302,7 +290,6 @@ class RiveViewTest {
     @Test
     fun viewSetResourceLoadArtboard() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
 
             view.setRiveResource(R.raw.multiple_animations)
@@ -322,7 +309,6 @@ class RiveViewTest {
     @Test
     fun viewSetResourceLoadArtboardArtboardGotcha() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
 
             view.setRiveResource(R.raw.multiple_animations, artboardName = "New Artboard")
@@ -333,7 +319,6 @@ class RiveViewTest {
     @Test
     fun viewSetResourceLoadArtboardArtboardGotchaOK() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
 
             view.setRiveResource(R.raw.multiple_animations, artboardName = "New Artboard")
@@ -345,7 +330,6 @@ class RiveViewTest {
     @Test
     fun viewStop() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multipleartboards)
@@ -363,7 +347,6 @@ class RiveViewTest {
     @Test
     fun viewStopMultiple() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             view.play(listOf("one", "two", "three", "four"))
@@ -404,7 +387,6 @@ class RiveViewTest {
     @Test
     fun viewStopOneByOne() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
             view.play(listOf("one", "two", "three", "four"))
@@ -446,7 +428,6 @@ class RiveViewTest {
     @Test
     fun viewStopAnimationDetailsTime() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
@@ -465,7 +446,6 @@ class RiveViewTest {
     @Test
     fun viewPauseAnimationDetailsTime() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
@@ -487,7 +467,6 @@ class RiveViewTest {
         // pretty basic test. we could start seeing if the artboards properties are reset properly
         // but we actually would need to expose a lot more of that to do this.
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = false)
@@ -503,7 +482,6 @@ class RiveViewTest {
     @Test
     fun viewResetAutoplay() {
         UiThreadStatement.runOnUiThread {
-            val appContext = initTests()
 
             val view = RiveAnimationView(appContext)
             view.setRiveResource(R.raw.multiple_animations, autoplay = true)

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveViewTest.kt
@@ -26,7 +26,7 @@ class RiveViewTest {
     }
 
     @Test
-    fun viewDefaultsLoadResouce() {
+    fun viewDefaultsLoadResource() {
         UiThreadStatement.runOnUiThread {
 
             val view = RiveAnimationView(appContext)

--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/TestUtils.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/TestUtils.kt
@@ -2,14 +2,31 @@ package app.rive.runtime.kotlin.core
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
-import app.rive.runtime.kotlin.core.Rive
+import app.rive.runtime.kotlin.renderers.RendererSwappy
 import org.junit.Assert.assertEquals
 
 
-fun initTests(): Context {
-    val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-    assertEquals("app.rive.runtime.kotlin.test", appContext.packageName)
+class TestUtils {
+    private lateinit var testRenderer: MockRenderer
 
-    Rive.init(appContext)
-    return appContext
+    val context: Context by lazy {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("app.rive.runtime.kotlin.test", appContext.packageName)
+
+        Rive.init(appContext)
+        testRenderer = MockRenderer()
+
+        appContext
+    }
+
+
+    private class MockRenderer : RendererSwappy() {
+        init {
+            println("Got this mock initialized!")
+        }
+
+        override fun draw() {}
+        override fun advance(elapsed: Float) {}
+    }
 }
+

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveAnimationView.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveAnimationView.kt
@@ -187,6 +187,7 @@ class RiveAnimationView(context: Context, attrs: AttributeSet? = null) :
                     drawable.artboardName = artboardName
                     drawable.animationName = animationName
                     drawable.stateMachineName = stateMachineName
+                    drawable.advance(0.0f)
 
                     // If a URL has been provided, initiate downloading
                     url?.let {
@@ -529,9 +530,7 @@ class RiveAnimationView(context: Context, attrs: AttributeSet? = null) :
         drawable.artboardName = artboardName
 
         drawable.setRiveFile(file)
-//        background = drawable
-
-//        requestLayout()
+        drawable.advance(0.0f)
     }
 
     override fun onDetachedFromWindow() {

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveDrawable.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveDrawable.kt
@@ -345,9 +345,7 @@ class RiveDrawable(
 
     }
 
-    private fun _play(
-        stateMachineInstance: StateMachineInstance,
-    ) {
+    private fun _play(stateMachineInstance: StateMachineInstance) {
         if (!stateMachines.contains(stateMachineInstance)) {
             stateMachines.add(stateMachineInstance)
         }


### PR DESCRIPTION
Refactored the tests setup to include a `MockRenderer` that sets up the most basic cpp structures.
Make sure we `advance()` upon setting Rive resource and when firing states in tests.
In fact, this is slightly different now having a thread running in the background and managing playback: in fact, in our mock, we don't yet instantiate the OpenGL surface and all the jazz that comes along with it so, when we need to validate that a state has fired, we have to manually advance it.