### PR TITLE
fix: trigger start to draw at least first frame on artboard selection…

### DIFF
--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveArtboardRenderer.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveArtboardRenderer.kt
@@ -142,6 +142,7 @@ class RiveArtboardRenderer(
         selectedArtboard?.let {
             setArtboard(it)
         }
+        start()
     }
 
     fun play(
@@ -442,6 +443,7 @@ class RiveArtboardRenderer(
         } else {
             this.activeArtboard?.advance(0f)
         }
+        start()
     }
 
     /* LISTENER INTERFACE */


### PR DESCRIPTION
fixes #196 

small one, start is not the most aptly named call of em all, as its a bit confusing in comparison to play #138 

but this change will cause the first frame to get drawn when a new artboard/file is selected / when we call reset. the android player is a good example of this. 

didn't wanna get too far into this, as i know you're in the mix of the choreographer