### PR TITLE
chore: step back core-ktx and appcompat to allow for a lower compileS…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.fragment:fragment-ktx:1.3.6'

--- a/compatibilitytest/build.gradle
+++ b/compatibilitytest/build.gradle
@@ -32,9 +32,8 @@ android {
 }
 
 dependencies {
-
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation project(path: ':kotlin')

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     implementation 'com.android.volley:volley:1.2.1'
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.getkeepsafe.relinker:relinker:1.4.4'
     implementation 'androidx.startup:startup-runtime:1.1.0'
 


### PR DESCRIPTION
…DKVersion temporarily

fixes #209

i think we'll want to step these versions up again at some point, but right now this allows our app consumers to use sdk30 to compile. 