### PR TITLE
update autoplay behaviour for state machine initialisation

### DIFF
--- a/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineStateResolutionTest.kt
+++ b/kotlin/src/androidTest/java/app/rive/runtime/kotlin/core/RiveStateMachineStateResolutionTest.kt
@@ -35,7 +35,7 @@ class RiveStateMachineStateResolutionTest {
     }
 
     @Test
-    fun autoPlayDoesNotTriggerStateResolution() {
+    fun autoPlayTriggersStateResolution() {
         UiThreadStatement.runOnUiThread {
             val observer = TestUtils.Observer()
             mockView.registerListener(observer)
@@ -43,6 +43,19 @@ class RiveStateMachineStateResolutionTest {
                 R.raw.state_machine_state_resolution,
                 stateMachineName = "StateResolution",
                 autoplay = true
+            )
+            assertEquals(1, observer.states.size)
+        }
+    }
+    @Test
+    fun disablingAutoplaySuppressesStateResolution() {
+        UiThreadStatement.runOnUiThread {
+            val observer = TestUtils.Observer()
+            mockView.registerListener(observer)
+            mockView.setRiveResource(
+                R.raw.state_machine_state_resolution,
+                stateMachineName = "StateResolution",
+                autoplay = false
             )
             assertEquals(0, observer.states.size)
         }
@@ -56,7 +69,9 @@ class RiveStateMachineStateResolutionTest {
             mockView.setRiveResource(
                 R.raw.state_machine_state_resolution,
                 stateMachineName = "StateResolution",
+                autoplay = false
             )
+
             mockView.play("StateResolution", isStateMachine = true)
             assertEquals(1, observer.states.size)
 
@@ -73,6 +88,7 @@ class RiveStateMachineStateResolutionTest {
             mockView.setRiveResource(
                 R.raw.state_machine_state_resolution,
                 stateMachineName = "StateResolution",
+                autoplay = false
             )
             mockView.play(
                 "StateResolution",
@@ -91,6 +107,7 @@ class RiveStateMachineStateResolutionTest {
             mockView.setRiveResource(
                 R.raw.state_machine_state_resolution,
                 stateMachineName = "StateResolution",
+                autoplay = false
             )
             mockView.setNumberState("StateResolution", "Choice", 1f)
             mockView.play(
@@ -112,6 +129,7 @@ class RiveStateMachineStateResolutionTest {
             mockView.setRiveResource(
                 R.raw.state_machine_state_resolution,
                 stateMachineName = "StateResolution",
+                autoplay = false
             )
             mockView.setNumberState("StateResolution", "Choice", 2f)
             mockView.play(
@@ -136,6 +154,7 @@ class RiveStateMachineStateResolutionTest {
             mockView.setRiveResource(
                 R.raw.state_machine_state_resolution,
                 stateMachineName = "StateResolution",
+                autoplay = false
             )
             mockView.setNumberState("StateResolution", "Choice", 2f)
             mockView.play(

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveArtboardRenderer.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveArtboardRenderer.kt
@@ -449,11 +449,11 @@ open class RiveArtboardRenderer(
                 play(animationName = it)
             } ?: run {
                 stateMachineName?.let {
-                    // only settle initial state on explicit play call
-                    play(animationName = it, isStateMachine = true, settleInitialState = false)
+                    // With autoplay, we default to settling the initial state
+                    play(animationName = it, isStateMachine = true, settleInitialState = true)
                 } ?: run {
-                    // only settle initial state on explicit play call
-                    play(settleInitialState = false)
+                    // With autoplay, we default to settling the initial state
+                    play(settleInitialState = true)
                 }
 
             }


### PR DESCRIPTION
i think this is more consistent with our approach of resolving the state machine when we play by default. 

you can still control it, just disable autoplay (i think the way i had it defaulted play to resolving, and autoplay to not resolving which is weird)