### PR TITLE
bugfix: add synchronized to avoid list operations that are not thread…

### DIFF
--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveArtboardRenderer.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveArtboardRenderer.kt
@@ -96,6 +96,8 @@ open class RiveArtboardRenderer(
         }
     }
 
+    /// Note: This is happening in the render thread
+    /// be aware of thread safety!
     override fun advance(elapsed: Float) {
         activeArtboard?.let { ab ->
             // animations could change, lets cut a list.
@@ -346,13 +348,13 @@ open class RiveArtboardRenderer(
     }
 
     private fun _animations(animationNames: Collection<String>): List<LinearAnimationInstance> {
-        return animationList.filter { animationInstance ->
+        return animations.filter { animationInstance ->
             animationNames.contains(animationInstance.animation.name)
         }
     }
 
     private fun _stateMachines(animationNames: Collection<String>): List<StateMachineInstance> {
-        return stateMachineList.filter { stateMachineInstance ->
+        return stateMachines.filter { stateMachineInstance ->
             animationNames.contains(stateMachineInstance.stateMachine.name)
         }
     }


### PR DESCRIPTION
… safe in our high level renderer

this is the "lock" approach  

note: re-entrant lock which should not be meaningful here, just more of a just in case. 
note: no tryLock -> skip approach (I've had that in before, but that would mess up timings over time)

I've not been able to reproduce the race conditions in a normal setting.

But creating an activity that calls view.stop & play every 10 nanoseconds in a subthread does the trick as long as you comment out `stopThread()` in RiveArtboardRenderer.kt (which runs you into looper issues). 

```kotlin
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.concurrent)
        var view = findViewById<RiveAnimationView>(R.id.simple_view_asset)

        var count = 0

        thread {
            while (true) {
                Thread.sleep(0, 10)
                if ((count) % 2 == 0) {
                    view.stop()
//                    view.pause()
                } else {
                    view.play()
                }
                count++
            }
            true
        }

    }
```

performance wise this seems to be in the ballpark of what we have previously had, the reading I get from our Metrics activity change day by day. But right now I'm getting no locks to settle on 4.40ms and with locks to settle on 4.39ms after a few minutes. but yesterday I settled on 4.44ms, & 4.50ms, so there is certainly some other variation to take into account here. 