### PR TITLE
Add small fix for release workflow to avoid pr closing edge case

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish:
     name: Release build and publish
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
So that these publish flows only get run when PR's to master are closed and merged