### PR TITLE
Virtualization fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "app.rive.runtime.example"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -36,6 +36,9 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,7 @@
         <activity android:name=".RecyclerActivity" />
         <activity android:name=".MeshesActivity" />
         <activity android:name=".ViewStubActivity" />
+        <activity android:name=".ViewPagerActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/app/rive/runtime/example/AndroidPlayerActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/AndroidPlayerActivity.kt
@@ -21,8 +21,9 @@ class AndroidPlayerActivity : AppCompatActivity() {
     var stopButtonMap: HashMap<String, View> = HashMap()
 
     private val animationResources = listOf(
-        R.raw.artboard_animations,
+        R.raw.circle_move,
         R.raw.basketball,
+        R.raw.artboard_animations,
         R.raw.clipping,
         R.raw.explorer,
         R.raw.f22,

--- a/app/src/main/java/app/rive/runtime/example/MainActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/MainActivity.kt
@@ -22,6 +22,7 @@ class MainActivity : AppCompatActivity() {
         Pair(R.id.go_metrics, MetricsActivity::class.java),
         Pair(R.id.go_assets, AssetsActivity::class.java),
         Pair(R.id.go_recycler, RecyclerActivity::class.java),
+        Pair(R.id.go_viewpager, ViewPagerActivity::class.java),
         Pair(R.id.go_meshes, MeshesActivity::class.java),
         Pair(R.id.go_viewstub, ViewStubActivity::class.java),
     )

--- a/app/src/main/java/app/rive/runtime/example/RecyclerActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/RecyclerActivity.kt
@@ -1,5 +1,6 @@
 package app.rive.runtime.example
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -27,11 +28,11 @@ data class RiveFileResource(val number: Int, val resource: Int)
 
 object RiveFileDiffCallback : DiffUtil.ItemCallback<RiveFileResource>() {
     override fun areItemsTheSame(oldItem: RiveFileResource, newItem: RiveFileResource): Boolean {
-        return oldItem.number == oldItem.number
+        return oldItem.number == newItem.number
     }
 
     override fun areContentsTheSame(oldItem: RiveFileResource, newItem: RiveFileResource): Boolean {
-        return oldItem.number == oldItem.number
+        return oldItem.number == newItem.number
     }
 }
 
@@ -59,6 +60,12 @@ class RiveAdapter :
 
     override fun onBindViewHolder(holder: RiveViewHolder, position: Int) {
         val riveFileResource = getItem(position)
+        // Alternate background colors to differentiate various elements.
+        if (position % 2 == 1) {
+            holder.itemView.setBackgroundColor(Color.parseColor("#FFFFFF"));
+        } else {
+            holder.itemView.setBackgroundColor(Color.parseColor("#FFFAF8FD"));
+        }
         holder.bind(riveFileResource)
     }
 
@@ -67,6 +74,11 @@ class RiveAdapter :
     }
 
     override fun getItem(position: Int): RiveFileResource {
-        return RiveFileResource(position, R.raw.circle_move)
+        val res = if (position % 2 == 1) {
+            R.raw.basketball
+        } else {
+            R.raw.circle_move
+        }
+        return RiveFileResource(position, res)
     }
 }

--- a/app/src/main/java/app/rive/runtime/example/ViewPagerActivity.kt
+++ b/app/src/main/java/app/rive/runtime/example/ViewPagerActivity.kt
@@ -1,0 +1,85 @@
+package app.rive.runtime.example
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import app.rive.runtime.example.databinding.ViewPagerRiveWrapperBinding
+import app.rive.runtime.example.databinding.ViewPagerBinding
+
+
+class ViewPagerActivity : AppCompatActivity() {
+    private lateinit var binding: ViewPagerBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+
+        binding = ViewPagerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.viewPager.apply {
+            adapter = RiveViewPagerAdapter().apply {
+                submitList(
+                    listOf(
+                        R.raw.basketball,
+                        R.raw.off_road_car_blog,
+                        R.raw.flux_capacitor,
+                        R.raw.artboard_animations,
+                    )
+                )
+            }
+        }
+    }
+
+    private class RiveTestViewHolder(val binding: ViewPagerRiveWrapperBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(res: Int) {
+            binding.riveTestView.setRiveResource(res)
+        }
+    }
+
+    private class RiveViewPagerAdapter :
+        ListAdapter<Int, RiveTestViewHolder>(object : DiffUtil.ItemCallback<Int>() {
+            override fun areItemsTheSame(oldItem: Int, newItem: Int): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: Int, newItem: Int): Boolean {
+                return oldItem == newItem
+            }
+        }) {
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RiveTestViewHolder {
+            val binding =
+                ViewPagerRiveWrapperBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            return RiveTestViewHolder(binding)
+        }
+
+        override fun onBindViewHolder(holder: RiveTestViewHolder, position: Int) {
+            getItem(position).let {
+                holder.bind(it)
+            }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        // menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        return when (item.itemId) {
+            // R.id.action_settings -> true
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -108,6 +108,12 @@
                 android:text="Recycler" />
 
             <Button
+                android:id="@+id/go_viewpager"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="ViewPager" />
+
+            <Button
                 android:id="@+id/go_meshes"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/view_pager.xml
+++ b/app/src/main/res/layout/view_pager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ViewPagerActivity">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/view_pager_rive_wrapper.xml
+++ b/app/src/main/res/layout/view_pager_rive_wrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <app.rive.runtime.kotlin.RiveAnimationView
+        android:id="@+id/riveTestView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/cpp/build.rive.for.sh
+++ b/cpp/build.rive.for.sh
@@ -20,6 +20,8 @@ usage() {
     printf "Usage: %s -a arch [-c]" "$0"
     printf "\t-a Specify an architecture (i.e. '%s', '%s', '%s', '%s')", $ARCH_X86 $ARCH_X64 $ARCH_ARM $ARCH_ARM64
     printf "\t-c Clean previous builds\n"
+    printf "\t-d To build for debug (which also enables logging)\n"
+    printf "\t-l To enable logging\n"
     exit 1 # Exit script after printing help
 }
 

--- a/cpp/include/bindings/bindings_renderer_skia.hpp
+++ b/cpp/include/bindings/bindings_renderer_skia.hpp
@@ -24,6 +24,7 @@ extern "C"
 
     JNIEXPORT void JNICALL Java_app_rive_runtime_kotlin_renderers_RendererSkia_cppStart(JNIEnv*,
                                                                                         jobject,
+                                                                                        jlong,
                                                                                         jlong);
 
     JNIEXPORT void JNICALL

--- a/cpp/include/models/jni_renderer_skia.hpp
+++ b/cpp/include/models/jni_renderer_skia.hpp
@@ -23,7 +23,7 @@ public:
 
     void doFrame(long frameTimeNs);
 
-    void start();
+    void start(long timeNs);
 
     void stop();
 

--- a/cpp/src/bindings/bindings_renderer_skia.cpp
+++ b/cpp/src/bindings/bindings_renderer_skia.cpp
@@ -49,9 +49,10 @@ extern "C"
     JNIEXPORT void JNICALL
     Java_app_rive_runtime_kotlin_renderers_RendererSkia_cppStart(JNIEnv*,
                                                                  jobject,
-                                                                 jlong rendererRef)
+                                                                 jlong rendererRef,
+                                                                 jlong frameTimeNs)
     {
-        reinterpret_cast<JNIRendererSkia*>(rendererRef)->start();
+        reinterpret_cast<JNIRendererSkia*>(rendererRef)->start(frameTimeNs);
     }
 
     JNIEXPORT void JNICALL

--- a/cpp/src/helpers/general.cpp
+++ b/cpp/src/helpers/general.cpp
@@ -293,7 +293,7 @@ void logThread()
     while (1)
     {
         fgets(readBuffer, sizeof(readBuffer), inputFile);
-        __android_log_write(2, "stderr", readBuffer);
+        __android_log_write(2, "android_stderr", readBuffer);
     }
 }
 

--- a/cpp/src/models/jni_renderer_skia.cpp
+++ b/cpp/src/models/jni_renderer_skia.cpp
@@ -66,7 +66,6 @@ void JNIRendererSkia::setWindow(ANativeWindow* window)
         auto gpuSurface = threadState->getSkiaSurface();
         mGpuCanvas = gpuSurface->getCanvas();
         mSkRenderer = new rive::SkiaRenderer(mGpuCanvas);
-        LOGW("Set Window Time: %ld", threadState->mLastUpdate);
     });
 }
 
@@ -74,14 +73,11 @@ void JNIRendererSkia::doFrame(long frameTimeNs)
 {
     if (mIsDoingFrame)
     {
-        LOGW("Already doing frame!");
         return;
     }
     mIsDoingFrame = true;
     bool hasQueued = mWorkerThread->run([=](EGLThreadState* threadState) {
         float elapsedMs = threadState->getElapsedMs(frameTimeNs);
-        LOGW("doFrame() Time: %ld vs %ld", threadState->mLastUpdate, frameTimeNs);
-        LOGW("\tAdvance elapsed: %.2f", elapsedMs);
         threadState->mLastUpdate = frameTimeNs;
 
         auto env = getJNIEnv();

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveTextureView.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveTextureView.kt
@@ -28,6 +28,7 @@ abstract class RiveTextureView(context: Context, attrs: AttributeSet? = null) :
     }
 
     protected abstract val renderer: RendererSkia
+    private lateinit var viewSurface: Surface
 
     private val refreshPeriodNanos: Long by lazy {
         val msInNS: Long = 1000000
@@ -68,8 +69,8 @@ abstract class RiveTextureView(context: Context, attrs: AttributeSet? = null) :
         width: Int,
         height: Int
     ) {
-        val surface = Surface(surfaceTexture)
-        renderer.setSurface(surface)
+        viewSurface = Surface(surfaceTexture)
+        renderer.setSurface(viewSurface)
     }
 
     @CallSuper
@@ -89,7 +90,7 @@ abstract class RiveTextureView(context: Context, attrs: AttributeSet? = null) :
 
     @CallSuper
     override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
-        // Returning true will `release()` for us
-        return true
+        viewSurface.release()
+        return false
     }
 }


### PR DESCRIPTION
- Adds a `ViewPager` example with Horizontal scrolling
- Fixes a few issues with timers being unreliable
- Does not reload the file if already loaded
- Fix `disposeDependencies()` visibility and properly clean up the `file` when calling it in the subclass
- Add a few fields to `DetachedState` so it's more resilient and it can restore the right animation
- Adds a tweaks to the `RecyclerView` example

I'm curious to see if this addresses also those reports about `RecyclerView` from our issue tracker, from my testing this seems more resilient now.