### PR TITLE
Fix bug crash on Android 15 (with 16KB page size support)

### DIFF
--- a/kotlin/src/main/cpp/CMakeLists.txt
+++ b/kotlin/src/main/cpp/CMakeLists.txt
@@ -128,3 +128,5 @@ target_link_libraries(rive-android
         ${gles-lib}
         jnigraphics
         )
+
+target_link_options(rive-android PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
### Description 

Following on this issue https://github.com/rive-app/rive-android/issues/329 and the guidance from AndroidDeveloper
https://developer.android.com/guide/practices/page-sizes#compile-r26-lower
native-code has to rebuilt in order to be compatible with Android 15.

```
target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
```
Updated CMakeLists.txt to enable 16 KB ELF alignment.