### PR TITLE
fix: native library loading

### DIFF
--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveInitializer.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveInitializer.kt
@@ -3,6 +3,7 @@ package app.rive.runtime.kotlin
 import android.content.Context
 import androidx.startup.Initializer
 import app.rive.runtime.kotlin.core.Rive
+import app.rive.runtime.kotlin.core.RiveInitialized
 
 /**
  * Initializes Rive; needs to be done at startup.
@@ -37,9 +38,9 @@ import app.rive.runtime.kotlin.core.Rive
  * In fact, if you want to provide a custom renderer type you'll need to init Rive manually.
  */
 
-class RiveInitializer : Initializer<Unit> {
-    override fun create(context: Context) {
-        return Rive.init(context)
+class RiveInitializer : Initializer<RiveInitialized> {
+    override fun create(context: Context): RiveInitialized {
+        return RiveInitialized(Rive.init(context))
     }
 
     override fun dependencies(): List<Class<out Initializer<*>>> {

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/core/NativeLoader.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/core/NativeLoader.kt
@@ -1,0 +1,62 @@
+package app.rive.runtime.kotlin.core
+
+import android.content.Context
+import android.os.Build
+import com.getkeepsafe.relinker.ReLinker
+
+internal object NativeLoader {
+
+    /**
+     * Loads specified library by name and covers edge cases.
+     * ReLinker is only needed for API Level < 23.
+     *
+     * @param context required for ReLinker
+     * @param name the name of the library to load
+     * @return `true` if successfully loaded
+     */
+    fun loadLibrary(context: Context, name: String): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return loadLibrary(name)
+        }
+
+        val relinkerLoaded = runCatching {
+            ReLinker.loadLibrary(context, name)
+        }.isSuccess
+
+        // Ignore ReLinker result first, since it catches some exception and may not be loaded
+        // resulting in false-positives
+        // Loading twice won't work anyway so there is no problem
+        return loadLibrary(name) || relinkerLoaded
+    }
+
+    /**
+     * Loads specified library by name and covers edge cases.
+     * May fail on some API Level < 23 devices.
+     *
+     * @param name the name of the library to load
+     * @return `true` if successfully loaded
+     */
+    private fun loadLibrary(name: String): Boolean {
+        var loaded = true
+
+        // normally it's just the name but some manufacturers mess with this
+        systemLoadLibrary(name) {
+            systemLoadLibrary("$name.so") {
+                systemLoadLibrary("lib$name") {
+                    systemLoadLibrary("lib$name.so") {
+                        loaded = false
+                    }
+                }
+            }
+        }
+        return loaded
+    }
+
+    private fun systemLoadLibrary(name: String, onError: () -> Unit = { }) {
+        if (runCatching {
+            System.loadLibrary(name)
+        }.isFailure) {
+            onError()
+        }
+    }
+}

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/core/Rive.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/core/Rive.kt
@@ -38,13 +38,15 @@ object Rive {
      *
      * @param defaultRenderer The default renderer to use when initializing [File] or
      *    [RiveAnimationView]. Defaults to [RendererType.Skia].
+     * @return `true` if initialized, `false` if some error occurred.
      */
-    fun init(context: Context, defaultRenderer: RendererType = RendererType.Rive) {
-        // NOTE: loadLibrary also allows us to specify a version, something we might want to take
-        //       advantage of
-        ReLinker.loadLibrary(context, RIVE_ANDROID)
+    fun init(context: Context, defaultRenderer: RendererType = RendererType.Rive): Boolean {
+        val loaded = NativeLoader.loadLibrary(context, RIVE_ANDROID)
         defaultRendererType = defaultRenderer
-        initializeCppEnvironment()
+        if (loaded) {
+            initializeCppEnvironment()
+        }
+        return loaded
     }
 
     /**

--- a/kotlin/src/main/java/app/rive/runtime/kotlin/core/RiveInitialized.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/core/RiveInitialized.kt
@@ -1,0 +1,13 @@
+package app.rive.runtime.kotlin.core
+
+import app.rive.runtime.kotlin.RiveInitializer
+
+/**
+ * Represents the result of the [Rive] initialization.
+ * Only used for [RiveInitializer] to be compatible with other initializers.
+ *
+ * @property success Indicates whether the initialization was successful.
+ */
+data class RiveInitialized(
+    val success: Boolean
+)


### PR DESCRIPTION
Introduce a NativeLoader which takes care of loading native libraries. ReLinker is not needed on API Level > 23 and causes more trouble than it solves.

Refs: #341