### PR TITLE
Make WorkerThread re-entrant & ~JNIRenderer async to address #381

### DIFF
--- a/kotlin/src/main/cpp/include/models/jni_renderer.hpp
+++ b/kotlin/src/main/cpp/include/models/jni_renderer.hpp
@@ -18,6 +18,8 @@ public:
 
     ~JNIRenderer();
 
+    void disposeAsync();
+
     void setSurface(SurfaceVariant);
 
     rive::Renderer* getRendererOnWorkerThread() const;

--- a/kotlin/src/main/cpp/src/bindings/bindings_renderer.cpp
+++ b/kotlin/src/main/cpp/src/bindings/bindings_renderer.cpp
@@ -49,7 +49,8 @@ extern "C"
                                                               jlong rendererRef)
     {
         JNIRenderer* renderer = reinterpret_cast<JNIRenderer*>(rendererRef);
-        delete renderer;
+        // Capture the raw pointer, post to the worker thread, return immediately:
+        renderer->disposeAsync();
     }
 
     JNIEXPORT void JNICALL

--- a/kotlin/src/main/cpp/src/models/jni_renderer.cpp
+++ b/kotlin/src/main/cpp/src/models/jni_renderer.cpp
@@ -42,6 +42,15 @@ JNIRenderer::~JNIRenderer()
     releaseSurface(&m_surface);
 }
 
+void JNIRenderer::disposeAsync()
+{
+    // Capture `this`, post to the worker; the destructor now runs on the worker thread.
+    m_worker->run([this](DrawableThreadState*)
+    {
+        delete this;
+    });
+}
+
 void JNIRenderer::setSurface(SurfaceVariant surface)
 {
     SurfaceVariant oldSurface = m_surface;


### PR DESCRIPTION
Spent some time on this this weekend as the relevant issue (#381) is completely blocking our ability to upgrade to Expo 53 / newArch which is a blocking issue for our company and our product for other reasons.

My goal was to make the minimal changeset necessary to address the destructor ANR while also maximizing chances of avoiding any other similar or related deadlocks in the relevant file(s).

I am able to reproduce this ANR ~90% of the time on my Pixel 7 device on both debug and release builds using the rive-react-native SDK version 9.4.0 - the reproduction is simply to mount a Rive component with autoplay enabled, then unmount it.

I have built locally and confirmed that this changeset fixes the issue completely (given the high repro rate before and no repro since, I am very confident it is resolved now) and also has introduced no other issues with Rive in our product (which uses it heavily).

The basic idea here is that, as the constructor itself already implies / intends based on its comment:
```
    // Grab a Global Ref to prevent Garbage Collection to clean up the object
    //  from under us since the destructor will be called from the render thread
    //  rather than the UI thread.
```

The destructor should be called from something _other than the UI thread itself_.  However, right now, in practice, at least from the rive-react-native usage pattern, this is _exactly_ the opposite of what happens.

So this change ensures that _any_ JNI caller will now queue up the destructor onto the worker thread instead of the calling thread (which might very well be the UI thread).

In order to facilitate this, it also adds some additional protections to ensure the worker is properly re-entrancy-safe.  It additionally makes some minor semantic changes to some other lock / mutex usages which i do not believe were 100% correct previously.

Happy to answer any questions or address any feedback on this; I'm not sure how quickly the project typically adopts fixes like this, but if you can give context on that it would be helpful, as we will likely need to make our own local build and deployment of our fork if that process will take longer than a few days (we urgently need to get this build out and this is the one thing blocking the release).

Thanks in advance!
-cojo
