### PR TITLE
Guard image decode with catch(Throwable) to prevent OOM crashes

### DIFF
--- a/kotlin/src/main/java/app/rive/runtime/kotlin/core/ImageDecoder.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/core/ImageDecoder.kt
@@ -27,7 +27,7 @@ object ImageDecoder {
             pixels[1] = height
             bitmap.getPixels(pixels, offset, width, 0, 0, width, height)
             pixels
-        } catch (e: Exception) {
+        } catch (t: Throwable) {
             IntArray(0)
         }
     }


### PR DESCRIPTION
Wrap the entire decodeToBitmap() body in a try/catch that handles Throwable. This ensures both Exception and OutOfMemoryError are caught, preventing the app from crashing on oversized or invalid image inputs. Instead, an empty IntArray is returned to JNI callers.