### PR TITLE
Fix NPE when navigating away from a screen with RiveUI

### DIFF
--- a/kotlin/src/main/kotlin/app/rive/RiveUI.kt
+++ b/kotlin/src/main/kotlin/app/rive/RiveUI.kt
@@ -256,14 +256,16 @@ fun RiveUI(
                 }
 
                 commandQueue.advanceStateMachine(stateMachineHandle, deltaTimeNs)
-                commandQueue.draw(
+                surface?.let { surface ->
+                  commandQueue.draw(
                     artboardHandle,
                     stateMachineHandle,
                     fit,
                     alignment,
-                    surface!!,
+                    surface,
                     clearColor
-                )
+                  )
+                }
             }
         }
     }


### PR DESCRIPTION
When navigating away from a screen with the RiveUI composable, there's a race condition that can lead to an NPE (stacktrace follows). The issue is that the `RiveSurface` is nulled out in one callback, while it's asserted to be non-null within a while loop in a coroutine. It is non-deterministic which will be called first, so we have to check whether or not `surface` is null rather than forcing it to be treated as non-null.

```
java.lang.NullPointerException
	at app.rive.RiveUIKt$RiveUI$7$2.invokeSuspend(RiveUI.kt:264)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at androidx.compose.ui.platform.AndroidUiDispatcher.performTrampolineDispatch(AndroidUiDispatcher.android.kt:79)
	at androidx.compose.ui.platform.AndroidUiDispatcher.access$performTrampolineDispatch(AndroidUiDispatcher.android.kt:41)
	at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.run(AndroidUiDispatcher.android.kt:57)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8705)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```