### PR TITLE
Fix Audio Won't Restart Bug (#396)

### DIFF
--- a/kotlin/src/main/cpp/src/models/worker_impl.cpp
+++ b/kotlin/src/main/cpp/src/models/worker_impl.cpp
@@ -53,7 +53,7 @@ void WorkerImpl::start(jobject ktRenderer,
     m_lastFrameTime = frameTime;
     m_isStarted = true;
     // Conditional from CMake on whether to include miniaudio
-#ifdef WITH_AUDIO
+#ifdef WITH_RIVE_AUDIO
     if (auto engine = rive::AudioEngine::RuntimeEngine(false))
     {
         engine->start();


### PR DESCRIPTION
This corrects what appears to be a bad merge conflict resolution in worker_impl.cpp that resulted in necessary code always being excluded from compilation.