### PR TITLE
Initialize layoutScaleFactorAutomatic to device density

### DIFF
--- a/kotlin/src/main/java/app/rive/runtime/kotlin/RiveAnimationView.kt
+++ b/kotlin/src/main/java/app/rive/runtime/kotlin/RiveAnimationView.kt
@@ -393,6 +393,7 @@ open class RiveAnimationView(context: Context, attrs: AttributeSet? = null) :
                     loop = rendererAttributes.loop,
                     autoplay = rendererAttributes.autoplay,
                 )
+                controller.layoutScaleFactorAutomatic = resources.displayMetrics.density
                 /**
                  * Attach the observer to give us lifecycle hooks.
                  *


### PR DESCRIPTION
Fixes #446 (issue 1)

## Problem

`layoutScaleFactorAutomatic` defaults to `1.0` in `RiveFileController` and is only set to device density in `onMeasure()`. If `resizeArtboard()` runs before `onMeasure` (the view hasn't been measured yet when `setRiveFile()` is called), it computes `pixelWidth / 1.0` instead of `pixelWidth / density`.

iOS [initializes scale factor at view init time](https://github.com/rive-app/rive-ios/blob/68513e97/Source/RiveView.swift#L38-L44).

## Fix

Set `controller.layoutScaleFactorAutomatic = resources.displayMetrics.density` right after controller creation in the `RiveAnimationView` constructor.