### PR TITLE
fix: use emulated TLS on armeabi-v7a to fix linker crashes on API < 29

### DIFF
--- a/kotlin/src/main/cpp/CMakeLists.txt
+++ b/kotlin/src/main/cpp/CMakeLists.txt
@@ -33,7 +33,10 @@ target_compile_options(rive-android PRIVATE
         -Wall # Enable all warnings
         -fno-exceptions # Disable C++ exceptions
         -fno-rtti # Disable C++ RTTI
-        $<$<CONFIG:Release>:-Oz>) # Optimize for size with -Oz in release
+        $<$<CONFIG:Release>:-Oz> # Optimize for size with -Oz in release
+        # Use emulated TLS on 32-bit ARM to avoid R_ARM_TLS_DTPMOD32 relocations
+        # (type 17) that the Android dynamic linker cannot handle on API < 29.
+        $<$<STREQUAL:${CMAKE_ANDROID_ARCH_ABI},armeabi-v7a>:-femulated-tls>)
 target_compile_definitions(rive-android PRIVATE
         RIVE_ANDROID=
         YOGA_EXPORT=


### PR DESCRIPTION
## Summary

Add `-femulated-tls` compile option for `armeabi-v7a` in `kotlin/src/main/cpp/CMakeLists.txt`. This prevents the JNI bridge code from generating native TLS relocations (`R_ARM_TLS_DTPMOD32`, type 17) that Android's dynamic linker cannot resolve on API < 29.

## Problem

Since rive-android 11.0.0, the compiled `librive-android.so` for armeabi-v7a contains a `R_ARM_TLS_DTPMOD32` relocation that causes `dlopen` to fail with "unknown reloc type 17" on Android 7–9 (API 24–28). This results in:

- **`UnsatisfiedLinkError`**: JNI methods (e.g., `FileAssetLoader.constructor()`) have no native backing
- **`MissingLibraryException`**: ReLinker cannot find native libraries during initialization

### Production impact (Phantom Wallet, last 7 days)

- **2,831 crash events** across **685 impacted users**
- 93% on Android 7–9, all armeabi-v7a architecture
- Affected devices: Samsung J-series, Huawei Y5/Y6, Infinix, Itel

## Root Cause

The specific source of the TLS relocation is `hydro_random_context` — a 64-byte `__thread` variable in **libhydrogen** (`impl/random.h`), a dependency of the scripting (Luau) feature added in 11.0.0. The `__thread` attribute persists through LTO bitcode compilation and generates a native `R_ARM_TLS_DTPMOD32` in the final shared library.

The primary fix is in the companion rive-runtime PR (rive-app/rive-runtime#93), which:
1. Adds `-femulated-tls` to Premake build options for ARM32
2. Defines `TLS=` (empty) for ARM32 to override libhydrogen's `__thread` macro, converting `hydro_random_context` to a plain static variable (safe: Rive scripting is single-threaded on Android)

This PR adds `-femulated-tls` to the CMake build for the JNI bridge code as a defense-in-depth measure against any future `thread_local` usage.

## Verification

Built `librive-android.so` for armeabi-v7a and compared using `llvm-readelf`:

| Build | R_ARM_TLS_DTPMOD32 | TLS segment | __tls_get_addr |
|---|---|---|---|
| 10.5.1 (known working) | 0 | None | None |
| 11.4.0 (unfixed) | 1 | Yes (64 bytes) | Yes |
| **11.4.0 + fix** | **0** | **None** | **None** |

The fixed build matches the known-working 10.5.1 baseline exactly: zero TLS relocations, zero TLS symbols, no TLS program header.

## Testing

```bash
# Build for armeabi-v7a only
./gradlew :kotlin:assembleRelease -PabiFilters=armeabi-v7a

# Verify no TLS relocations
llvm-readelf -r librive-android.so | grep R_ARM_TLS  # should be empty

# Verify no TLS program header
llvm-readelf -l librive-android.so | grep TLS  # should be empty
```

Install on an ARM32 device running Android 8 or 9 — verify no crash on Rive animation load.

## Related

- Companion: rive-app/rive-runtime#93 (Premake build flags + `TLS=` define)
- Fixes #445
- Fixes #441