### PR TITLE
Add getName to experimental ViewModelInstance API

### DIFF
--- a/kotlin/src/androidTest/kotlin/app/rive/core/ViewModelInstanceNameTest.kt
+++ b/kotlin/src/androidTest/kotlin/app/rive/core/ViewModelInstanceNameTest.kt
@@ -1,0 +1,93 @@
+package app.rive.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.rive.Artboard
+import app.rive.RiveAndroidTest
+import app.rive.ViewModelInstance
+import app.rive.ViewModelInstanceSource
+import app.rive.ViewModelSource
+import app.rive.runtime.kotlin.core.File
+import app.rive.runtime.kotlin.test.R
+import kotlinx.coroutines.runBlocking
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class ViewModelInstanceNameTest : RiveAndroidTest() {
+    @Test
+    fun getName_matchesClassicApiForAllCreationSources() {
+        val bytes = context.resources.openRawResource(R.raw.data_bind_test_impl)
+            .use { it.readBytes() }
+
+        // The classic API resolves names synchronously; use it as the source of truth for the
+        // names this fixture assigns.
+        val classicFile = File(bytes)
+        val classicVm = classicFile.getViewModelByName("Test All")
+        val classicDefault = classicVm.createDefaultInstance()
+        val expectedNamedName = classicVm.createInstanceFromName("Test Alternate").name
+        val expectedDefaultName = classicDefault.name
+        val expectedBlankName = classicVm.createBlankInstance().name
+        val expectedNestedName = classicDefault.getInstanceProperty("Test Nested").name
+
+        val classicListArtboard = classicFile.artboard("Test List")
+        val classicListOwner =
+            classicFile.defaultViewModelForArtboard(classicListArtboard).createDefaultInstance()
+        val expectedListItemName = classicListOwner.getListProperty("Test List")[0].name
+        classicFile.release()
+
+        // Fixture sanity: these names are distinct, so a wrong lookup cannot pass by accident.
+        assertEquals("Test Alternate", expectedNamedName)
+        assertEquals("Test Default", expectedDefaultName)
+        assertEquals("", expectedBlankName)
+
+        riveWorker.withPolling {
+            val fileHandle = runBlocking { loadFile(bytes) }
+            val vmSource = ViewModelSource.Named("Test All")
+
+            val named = createViewModelInstance(fileHandle, vmSource.namedInstance("Test Alternate"))
+            val default = createViewModelInstance(fileHandle, vmSource.defaultInstance())
+            val blank = createViewModelInstance(fileHandle, vmSource.blankInstance())
+
+            // Reference and list-item sources take the public wrapper type.
+            val defaultInstance = ViewModelInstance(default, riveWorker, fileHandle)
+            val nested = createViewModelInstance(
+                fileHandle,
+                ViewModelInstanceSource.Reference(defaultInstance, "Test Nested")
+            )
+
+            val listArtboard = Artboard(
+                createArtboardByName(fileHandle, "Test List"),
+                riveWorker,
+                fileHandle,
+                "Test List"
+            )
+            val listOwnerInstance = ViewModelInstance(
+                createViewModelInstance(
+                    fileHandle,
+                    ViewModelSource.DefaultForArtboard(listArtboard).defaultInstance()
+                ),
+                riveWorker,
+                fileHandle
+            )
+            val listItem = createViewModelInstance(
+                fileHandle,
+                ViewModelInstanceSource.ReferenceListItem(listOwnerInstance, "Test List", 0)
+            )
+
+            runBlocking {
+                assertEquals(expectedNamedName, getViewModelInstanceName(named))
+                assertEquals(expectedDefaultName, getViewModelInstanceName(default))
+                assertEquals(expectedBlankName, getViewModelInstanceName(blank))
+                assertEquals(expectedNestedName, getViewModelInstanceName(nested))
+                assertEquals(expectedListItemName, getViewModelInstanceName(listItem))
+            }
+
+            listOf(named, blank, nested, listItem).forEach { deleteViewModelInstance(it) }
+            listOwnerInstance.close()
+            defaultInstance.close()
+            listArtboard.close()
+            deleteFile(fileHandle)
+        }
+    }
+}

--- a/kotlin/src/main/cpp/src/bindings/bindings_command_queue.cpp
+++ b/kotlin/src/main/cpp/src/bindings/bindings_command_queue.cpp
@@ -21,6 +21,7 @@
 #include "rive/command_server.hpp"
 #include "rive/file.hpp"
 #include "rive/renderer/rive_render_image.hpp"
+#include "rive/viewmodel/runtime/viewmodel_instance_runtime.hpp"
 
 using namespace rive_android;
 
@@ -1958,6 +1959,65 @@ extern "C"
         commandQueue->requestViewModelInstanceListSize(viewModelInstanceHandle,
                                                        propertyPath,
                                                        requestID);
+    }
+
+    JNIEXPORT void JNICALL
+    Java_app_rive_core_CommandQueueJNIBridge_cppGetViewModelInstanceName(
+        JNIEnv* env,
+        jobject,
+        jlong ref,
+        jobject jQueue,
+        jlong requestID,
+        jlong jViewModelInstanceHandle)
+    {
+        auto commandQueue = reinterpret_cast<rive::CommandQueue*>(ref);
+        auto viewModelInstanceHandle =
+            handleFromLong<rive::ViewModelInstanceHandle>(
+                jViewModelInstanceHandle);
+
+        // The command queue protocol has no message carrying an instance's own
+        // name (only its view model's name), so resolve it with runOnce on the
+        // command server thread and call back into Kotlin from there.
+        auto jQueueRef = std::make_shared<JCommandQueue>(env, jQueue);
+        commandQueue->runOnce([jQueueRef,
+                               viewModelInstanceHandle,
+                               requestID](rive::CommandServer* server) {
+            auto* env = GetJNIEnv();
+            if (env == nullptr)
+            {
+                RiveLogE(TAG_CQ, "Failed to get command server JNIEnv");
+                return;
+            }
+
+            auto* instance =
+                server->getViewModelInstance(viewModelInstanceHandle);
+            if (instance != nullptr)
+            {
+                auto jName = MakeJString(env, instance->name());
+                jQueueRef->call("onViewModelInstanceNameReceived",
+                                "(JLjava/lang/String;)V",
+                                requestID,
+                                jName.get());
+            }
+            else
+            {
+                auto jError = MakeJString(
+                    env,
+                    "Invalid view model instance handle when requesting the "
+                    "instance name");
+                jQueueRef->call("onViewModelInstanceError",
+                                "(JLjava/lang/String;)V",
+                                requestID,
+                                jError.get());
+            }
+
+            // Clear any pending exception; there is no JNI frame to propagate
+            // to on the command server thread.
+            JNIExceptionHandler::ClearAndLogErrors(
+                env,
+                TAG_CQ,
+                "cppGetViewModelInstanceName: Exception in Kotlin callback:");
+        });
     }
 
     JNIEXPORT void JNICALL

--- a/kotlin/src/main/kotlin/app/rive/ViewModelInstance.kt
+++ b/kotlin/src/main/kotlin/app/rive/ViewModelInstance.kt
@@ -72,6 +72,22 @@ class ViewModelInstance internal constructor(
      */
     internal fun isOwnedBy(worker: RiveWorker): Boolean = riveWorker === worker
 
+    /**
+     * Gets the editor-assigned name of this view model instance, as resolved by the command
+     * server.
+     *
+     * This works for all creation sources, including names the caller could not know upfront,
+     * such as the name of the instance marked "Default" in the Rive file when created with
+     * [ViewModelInstanceSource.Default], or the name of a list item obtained with
+     * [ViewModelInstanceSource.ReferenceListItem].
+     *
+     * @return The name of this view model instance, or an empty string for instances without a
+     *    name, e.g. blank instances.
+     * @throws RuntimeException If this instance has been [closed][close].
+     * @throws IllegalStateException If the backing Rive worker has been released.
+     */
+    suspend fun getName(): String = riveWorker.getViewModelInstanceName(instanceHandle)
+
     private val _dirtyFlow = MutableSharedFlow<Unit>(
         replay = 1,
         extraBufferCapacity = 1,

--- a/kotlin/src/main/kotlin/app/rive/core/CommandQueue.kt
+++ b/kotlin/src/main/kotlin/app/rive/core/CommandQueue.kt
@@ -1921,6 +1921,46 @@ class CommandQueue internal constructor(
     }
 
     /**
+     * Gets the editor-assigned name of the view model instance.
+     *
+     * @param viewModelInstanceHandle The handle of the view model instance to query.
+     * @return The name of the view model instance, or an empty string for instances without a
+     *    name, e.g. blank instances.
+     * @throws RuntimeException If the view model instance handle is invalid.
+     * @throws IllegalStateException If the CommandQueue has been released.
+     * @throws CancellationException If the coroutine is cancelled before the operation completes.
+     */
+    @Throws(RuntimeException::class, IllegalStateException::class, CancellationException::class)
+    suspend fun getViewModelInstanceName(
+        viewModelInstanceHandle: ViewModelInstanceHandle
+    ): String = suspendNativeRequest { requestID ->
+        bridge.cppGetViewModelInstanceName(
+            cppPointer.pointer,
+            this@CommandQueue,
+            requestID,
+            viewModelInstanceHandle.handle
+        )
+    }
+
+    /**
+     * Callback when the view model instance name is retrieved, from [getViewModelInstanceName].
+     *
+     * Unlike most callbacks, this one is invoked from the command server thread rather than from
+     * [pollMessages], because it is delivered by a `runOnce` callback instead of a protocol
+     * message.
+     *
+     * @param requestID The request ID used when querying the name, used to complete the
+     *    continuation.
+     * @param name The name of the view model instance.
+     */
+    @Keep // Called from JNI
+    @Suppress("Unused")
+    @JvmName("onViewModelInstanceNameReceived")
+    internal fun onViewModelInstanceNameReceived(requestID: Long, name: String) {
+        (pendingContinuations.remove(requestID) as? Continuation<String>)?.resume(name)
+    }
+
+    /**
      * Inserts a view model instance into a list property at the specified index.
      *
      * @param viewModelInstanceHandle The handle of the view model instance that owns the list

--- a/kotlin/src/main/kotlin/app/rive/core/CommandQueueBridge.kt
+++ b/kotlin/src/main/kotlin/app/rive/core/CommandQueueBridge.kt
@@ -288,6 +288,13 @@ interface CommandQueueBridge {
         propertyPath: String
     )
 
+    fun cppGetViewModelInstanceName(
+        pointer: Long,
+        receiver: CommandQueue,
+        requestID: Long,
+        viewModelInstanceHandle: Long
+    )
+
     fun cppInsertToListAtIndex(
         pointer: Long,
         viewModelInstanceHandle: Long,
@@ -737,6 +744,13 @@ internal class CommandQueueJNIBridge : CommandQueueBridge {
         requestID: Long,
         viewModelInstanceHandle: Long,
         propertyPath: String
+    )
+
+    external override fun cppGetViewModelInstanceName(
+        pointer: Long,
+        receiver: CommandQueue,
+        requestID: Long,
+        viewModelInstanceHandle: Long
     )
 
     external override fun cppInsertToListAtIndex(

--- a/kotlin/src/test/kotlin/app/rive/CommandQueueUnitTest.kt
+++ b/kotlin/src/test/kotlin/app/rive/CommandQueueUnitTest.kt
@@ -512,6 +512,66 @@ class CommandQueueUnitTest : FunSpec({
         }
     }
 
+    test("Get view model instance name returns name") {
+        val commandQueue = CommandQueue(renderContextMock, commandQueueBridgeMock)
+        val requestID = slot<Long>()
+        val instanceHandle = ViewModelInstanceHandle(HANDLE_NUM)
+
+        every {
+            commandQueueBridgeMock.cppGetViewModelInstanceName(
+                COMMAND_QUEUE_ADDR,
+                commandQueue,
+                capture(requestID),
+                HANDLE_NUM
+            )
+        } answers {
+            commandQueue.onViewModelInstanceNameReceived(requestID.captured, "Test Default")
+        }
+
+        val result = commandQueue.getViewModelInstanceName(instanceHandle)
+
+        result shouldBe "Test Default"
+        verify(exactly = 1) {
+            commandQueueBridgeMock.cppGetViewModelInstanceName(
+                COMMAND_QUEUE_ADDR,
+                commandQueue,
+                requestID.captured,
+                HANDLE_NUM
+            )
+        }
+    }
+
+    test("Get view model instance name failure throws view model instance error") {
+        val commandQueue = CommandQueue(renderContextMock, commandQueueBridgeMock)
+        val requestID = slot<Long>()
+        val instanceHandle = ViewModelInstanceHandle(HANDLE_NUM)
+        val errorMessage = "Invalid view model instance handle when requesting the instance name"
+
+        every {
+            commandQueueBridgeMock.cppGetViewModelInstanceName(
+                COMMAND_QUEUE_ADDR,
+                commandQueue,
+                capture(requestID),
+                HANDLE_NUM
+            )
+        } answers {
+            commandQueue.onViewModelInstanceError(requestID.captured, errorMessage)
+        }
+
+        shouldThrow<RuntimeException> {
+            commandQueue.getViewModelInstanceName(instanceHandle)
+        }.message shouldContain errorMessage
+
+        verify(exactly = 1) {
+            commandQueueBridgeMock.cppGetViewModelInstanceName(
+                COMMAND_QUEUE_ADDR,
+                commandQueue,
+                requestID.captured,
+                HANDLE_NUM
+            )
+        }
+    }
+
     test("Set artboard property invokes native") {
         val commandQueue = CommandQueue(renderContextMock, commandQueueBridgeMock)
         val instanceHandle = ViewModelInstanceHandle(HANDLE_NUM)


### PR DESCRIPTION
## Summary

Adds `suspend fun ViewModelInstance.getName()` to the experimental API, returning the editor-assigned instance name resolved by the command server.

Consumers migrating from the classic API currently lose the instance name: `CommandQueue` only exposes `getViewModelInstanceNames(file, viewModelName)` (the per-view-model name list), which cannot tell an existing instance which one it is. Instances created by name echo back what the caller already knew, while default, blank, nested (reference-path) and list-item instances have no way to learn their name at all.

The command queue protocol has no message carrying an instance's own name (`getViewModelInstanceViewModelName` returns the view model's name), so the binding resolves it with `runOnce` on the command server thread via `CommandServer::getViewModelInstance()->name()` and calls back into Kotlin from there — no runtime protocol change needed.

Covered by unit tests and an instrumented test asserting parity with the classic API's `ViewModelInstance.name` for named, default, blank, nested and list-item instances against `data_bind_test_impl.riv`.

The same gap exists in the rive-ios experimental API (RiveRuntime 6.20.4 `ViewModelInstance` has no name member); the same design would apply there for parity.
