### PR TITLE
feat(compose): expose artboard volume in Compose runtime

### DIFF
--- a/kotlin/src/main/cpp/src/bindings/bindings_command_queue.cpp
+++ b/kotlin/src/main/cpp/src/bindings/bindings_command_queue.cpp
@@ -304,6 +304,13 @@ public:
                      jInstanceName.get());
     }
 
+    void onArtboardVolumeReceived(const rive::ArtboardHandle,
+                                  uint64_t requestID,
+                                  float volume) override
+    {
+        m_queue.call("onArtboardVolumeReceived", "(JF)V", requestID, volume);
+    }
+
 private:
     JCommandQueue m_queue;
 };
@@ -2455,6 +2462,37 @@ extern "C"
             handleFromLong<rive::ArtboardHandle>(jArtboardHandle);
 
         commandQueue->resetArtboardSize(artboardHandle);
+    }
+
+    JNIEXPORT void JNICALL
+    Java_app_rive_core_CommandQueueJNIBridge_cppSetArtboardVolume(
+        JNIEnv*,
+        jobject,
+        jlong ref,
+        jlong jArtboardHandle,
+        jfloat jVolume)
+    {
+        auto* commandQueue = reinterpret_cast<rive::CommandQueue*>(ref);
+        auto artboardHandle =
+            handleFromLong<rive::ArtboardHandle>(jArtboardHandle);
+        auto volume = static_cast<float_t>(jVolume);
+
+        commandQueue->setArtboardVolume(artboardHandle, volume);
+    }
+
+    JNIEXPORT void JNICALL
+    Java_app_rive_core_CommandQueueJNIBridge_cppRequestArtboardVolume(
+        JNIEnv*,
+        jobject,
+        jlong ref,
+        jlong requestID,
+        jlong jArtboardHandle)
+    {
+        auto* commandQueue = reinterpret_cast<rive::CommandQueue*>(ref);
+        auto artboardHandle =
+            handleFromLong<rive::ArtboardHandle>(jArtboardHandle);
+
+        commandQueue->requestArtboardVolume(artboardHandle, requestID);
     }
 
     JNIEXPORT jlong JNICALL

--- a/kotlin/src/main/kotlin/app/rive/Artboard.kt
+++ b/kotlin/src/main/kotlin/app/rive/Artboard.kt
@@ -110,6 +110,27 @@ class Artboard internal constructor(
      */
     @Throws(IllegalStateException::class)
     fun resetArtboardSize() = riveWorker.resetArtboardSize(artboardHandle)
+
+    /**
+     * Sets the audio [volume] for this artboard.
+     *
+     * ℹ️ Volume is propagated to all nested artboards. This is fire-and-forget; use [getVolume] to
+     * read the current value back.
+     *
+     * @param volume The volume level (0f = muted, 1f = full volume).
+     * @throws IllegalStateException If the Rive worker has been released.
+     */
+    @Throws(IllegalStateException::class)
+    fun setVolume(volume: Float) = riveWorker.setArtboardVolume(artboardHandle, volume)
+
+    /**
+     * Retrieves the current audio volume of this artboard.
+     *
+     * @return The current volume (0f = muted, 1f = full volume).
+     * @throws IllegalStateException If the Rive worker has been released.
+     */
+    @Throws(IllegalStateException::class)
+    suspend fun getVolume(): Float = riveWorker.getArtboardVolume(artboardHandle)
 }
 
 /**

--- a/kotlin/src/main/kotlin/app/rive/core/CommandQueue.kt
+++ b/kotlin/src/main/kotlin/app/rive/core/CommandQueue.kt
@@ -2579,6 +2579,60 @@ class CommandQueue internal constructor(
     )
 
     /**
+     * Sets the audio volume of an artboard.
+     *
+     * ℹ️ Volume is propagated to all nested artboards. This is fire-and-forget; use
+     * [getArtboardVolume] to read the current value back.
+     *
+     * @param artboardHandle The handle of the artboard whose volume should be set.
+     * @param volume The volume level to set (0f = muted, 1f = full volume).
+     * @throws IllegalStateException If the CommandQueue has been released.
+     */
+    @Throws(IllegalStateException::class)
+    fun setArtboardVolume(
+        artboardHandle: ArtboardHandle,
+        volume: Float
+    ) = bridge.cppSetArtboardVolume(
+        cppPointer.pointer,
+        artboardHandle.handle,
+        volume
+    )
+
+    /**
+     * Queries the current audio volume of an artboard. Returns on [onArtboardVolumeReceived].
+     *
+     * @param artboardHandle The handle of the artboard to query.
+     * @return The current volume of the artboard (0f = muted, 1f = full volume).
+     * @throws RuntimeException If the artboard handle is invalid.
+     * @throws IllegalStateException If the CommandQueue has been released.
+     * @throws CancellationException If the coroutine is cancelled before the operation completes.
+     */
+    @Throws(RuntimeException::class, IllegalStateException::class, CancellationException::class)
+    suspend fun getArtboardVolume(artboardHandle: ArtboardHandle): Float =
+        suspendNativeRequest { requestID ->
+            bridge.cppRequestArtboardVolume(
+                cppPointer.pointer,
+                requestID,
+                artboardHandle.handle
+            )
+        }
+
+    /**
+     * Callback when an artboard's volume is received, from [getArtboardVolume].
+     *
+     * @param requestID The request ID used when querying the volume, used to complete the
+     *    continuation.
+     * @param volume The current volume of the artboard.
+     */
+    @Keep // Called from JNI
+    @Suppress("Unused")
+    @JvmName("onArtboardVolumeReceived")
+    internal fun onArtboardVolumeReceived(requestID: Long, volume: Float) {
+        @Suppress("UNCHECKED_CAST")
+        (pendingContinuations.remove(requestID) as? Continuation<Float>)?.resume(volume)
+    }
+
+    /**
      * Draw the artboard with the given state machine.
      *
      * @param artboardHandle The handle of the artboard to draw.

--- a/kotlin/src/main/kotlin/app/rive/core/CommandQueueBridge.kt
+++ b/kotlin/src/main/kotlin/app/rive/core/CommandQueueBridge.kt
@@ -429,6 +429,18 @@ interface CommandQueueBridge {
         artboardHandle: Long
     )
 
+    fun cppSetArtboardVolume(
+        pointer: Long,
+        artboardHandle: Long,
+        volume: Float
+    )
+
+    fun cppRequestArtboardVolume(
+        pointer: Long,
+        requestID: Long,
+        artboardHandle: Long
+    )
+
     fun cppCreateDrawKey(pointer: Long): Long
     fun cppDraw(
         pointer: Long,
@@ -889,6 +901,18 @@ internal class CommandQueueJNIBridge : CommandQueueBridge {
 
     external override fun cppResetArtboardSize(
         pointer: Long,
+        artboardHandle: Long
+    )
+
+    external override fun cppSetArtboardVolume(
+        pointer: Long,
+        artboardHandle: Long,
+        volume: Float
+    )
+
+    external override fun cppRequestArtboardVolume(
+        pointer: Long,
+        requestID: Long,
         artboardHandle: Long
     )
 


### PR DESCRIPTION
## Summary

Wire artboard audio volume through the command-queue Compose runtime, mirroring the iOS Concurrency runtime implementation.

Adds first-class command-queue support for the native `setArtboardVolume` / `requestArtboardVolume` commands (already present in the pinned `rive-runtime`):

- **JNI:** `cppSetArtboardVolume` (fire-and-forget) + `cppRequestArtboardVolume` (request/response), plus `ArtboardListener::onArtboardVolumeReceived` routing the reply back to Kotlin.
- **CommandQueueBridge:** external declarations for both bindings.
- **CommandQueue:** `setArtboardVolume()` + suspend `getArtboardVolume()`, with the `onArtboardVolumeReceived` callback resuming the pending continuation.
- **Artboard:** public `setVolume(Float)` + suspend `getVolume()`.

## Verification

- C++ bindings compile and link against the NDK (arm64-v8a); the new JNI symbols (`cppSetArtboardVolume`, `cppRequestArtboardVolume`) and the `onArtboardVolumeReceived` override are present in the built `librive-android.so`.
- `./gradlew :kotlin:assembleDebug` succeeds (Kotlin + native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
